### PR TITLE
Feature vs8 dummy sample image class

### DIFF
--- a/Sources.cmake
+++ b/Sources.cmake
@@ -17,5 +17,5 @@ include_directories (${catch}/single_include)
 include_directories (src/)
 
 set (sources
-
+	"src/sample_image.cpp"
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,29 +5,27 @@
  * @license   MIT
  */
 
-#include "open_cv.hpp"
+#include "sample_image.hpp"
 #include <iostream>
 
 int main() {
-    cv::Mat image;
-
     ///< Specify path of image to be loaded
-    char imageName[] = "default.jpg";
-    std::cout << "Specify image path: " << std::endl;
-    std::cin >> imageName;
+    char path[] = "default.jpg";
+    std::cout << "Specify image path: \n";
+    std::cin >> path;
 
-    ///< Read image from file
-    image = cv::imread(imageName, -1);
+    ///< Create SampleImage object and place path inside of it
+    SampleImage sampleImage(path);
 
     ///< Check if image could be loaded
-    if (!image.data) {
+    if (!sampleImage.getIsValid()) {
         std::cout << "Could not open or find the image" << std::endl;
         return -1;
     }
 
     ///< Create window and display image
     cv::namedWindow("Display window", cv::WINDOW_AUTOSIZE);
-    cv::imshow("Display window", image);
+    cv::imshow("Display window", sampleImage.getImage());
 
     ///< Wait for key stroke
     cv::waitKey(0);

--- a/src/sample_image.cpp
+++ b/src/sample_image.cpp
@@ -7,5 +7,5 @@
 
 #include "sample_image.hpp"
 
-SampleImage::SampleImage() {	
+SampleImage::SampleImage() {
 }

--- a/src/sample_image.cpp
+++ b/src/sample_image.cpp
@@ -21,7 +21,7 @@ SampleImage::SampleImage(const char *path) : path(path) {
 }
 
 ///< Setters
-void SampleImage::set(const char *newPath) {
+void SampleImage::setPath(const char *newPath) {
     path = newPath;
     image = cv::imread(path, -1);
     if (!image.data) {
@@ -29,8 +29,8 @@ void SampleImage::set(const char *newPath) {
         isValid = false;
     }
 }
-void SampleImage::set(SampleImage &other) {
-    if (other.isValid()) {
+void SampleImage::setPath(SampleImage &other) {
+    if (other.getIsValid()) {
         path = other.getPath();
         image = cv::imread(path, -1);
     } else {
@@ -39,12 +39,12 @@ void SampleImage::set(SampleImage &other) {
 }
 
 ///< Getters
-char *SampleImage::getPath() {
+const char *SampleImage::getPath() {
     return path;
 }
-cv::mat getImage() {
+cv::Mat SampleImage::getImage() {
     return image;
 }
-bool SampleImage::isValid() {
+bool SampleImage::getIsValid() {
     return isValid;
 }

--- a/src/sample_image.cpp
+++ b/src/sample_image.cpp
@@ -1,0 +1,11 @@
+/**
+ * @file	  sample_image.cpp
+ * @brief     SampleImage class that contains the sample library to extract features from.
+ * @author    Roxanne van der Pol
+ * @license   MIT
+ */
+
+#include "sample_image.hpp"
+
+SampleImage::SampleImage() {	
+}

--- a/src/sample_image.cpp
+++ b/src/sample_image.cpp
@@ -7,5 +7,44 @@
 
 #include "sample_image.hpp"
 
-SampleImage::SampleImage() {
+///< Constructors
+SampleImage::SampleImage() : isValid(false) {
+}
+SampleImage::SampleImage(const char *path) : path(path) {
+    image = cv::imread(path, -1);
+    if (!image.data) {
+        std::cout << "Invalid image path!\n";
+        isValid = false;
+    } else {
+        isValid = true;
+    }
+}
+
+///< Setters
+void SampleImage::set(const char *newPath) {
+    path = newPath;
+    image = cv::imread(path, -1);
+    if (!image.data) {
+        std::cout << "Invalid image path!\n";
+        isValid = false;
+    }
+}
+void SampleImage::set(SampleImage &other) {
+    if (other.isValid()) {
+        path = other.getPath();
+        image = cv::imread(path, -1);
+    } else {
+        std::cout << "Other SampleImage image path was invalid!\n";
+    }
+}
+
+///< Getters
+char *SampleImage::getPath() {
+    return path;
+}
+cv::mat getImage() {
+    return image;
+}
+bool SampleImage::isValid() {
+    return isValid;
 }

--- a/src/sample_image.hpp
+++ b/src/sample_image.hpp
@@ -9,11 +9,9 @@
 #define SAMPLE_IMAGE_HPP
 
 class SampleImage {
-private:
-	
-public:
-	SampleImage();
-	
+  private:
+  public:
+    SampleImage();
 };
 
 #endif // SAMPLE_IMAGE_HPP

--- a/src/sample_image.hpp
+++ b/src/sample_image.hpp
@@ -10,8 +10,73 @@
 
 class SampleImage {
   private:
+    const char *path; ///< Path of image.
+    bool isValid;     ///< Whether an image path is valid
+    cv::Mat image;    ///< Image object which has a path
+
   public:
+    /**
+     * @brief Constructor of SampleImage class
+     *
+     * Creates a SampleImage object with no initialised parameters such as path or image. Sets isValid automatically to false.
+     */
     SampleImage();
+    /**
+     * @brief Overloaded constructor of SampleImage class
+     *
+     * Creates a SampleImage object; initialises image with a path and will set isValid to true if the path is valid.
+     *
+     * @param[in]     const char * newPath    The path of the image
+     */
+    SampleImage(const char *newPath);
+
+    /**
+     * @brief Sets path of image
+     *
+     * Sets the path of the SampleImage image by asking the user for input.
+     */
+    void setPath();
+    /**
+     * @brief Sets path of image
+     *
+     * Sets the path of the SampleImage image with a new const char * path. If the newPath is invalid, isValid will become false.
+     *
+     * @param[in]     const char * newPath    The path of the image
+     */
+    void setPath(const char *newPath);
+    /**
+     * @brief Sets path of image
+     *
+     * Sets the path of the SampleImage image using the path of an other SampleImage image.
+     *
+     * @param[in]     SampleImage & other    The path of an other SampleImage image
+     */
+    void setPath(SampleImage &other);
+
+    /**
+     * @brief Gets path of image
+     *
+     * Returns the private variable 'path'; a simple getter function.
+     *
+     * @return char * path
+     */
+    char *getPath();
+    /**
+     * @brief Gets image
+     *
+     * Returns the private variable 'image'; a simple getter function.
+     *
+     * @return cv::Mat image
+     */
+    cv::Mat getImage();
+    /**
+     * @brief Returns whether path is valid
+     *
+     * Returns the member variable 'isValid'. Is true if the path of an image is valid; false if it is not.
+     *
+     * @return bool isValid
+     */
+    bool isValid();
 };
 
 #endif // SAMPLE_IMAGE_HPP

--- a/src/sample_image.hpp
+++ b/src/sample_image.hpp
@@ -1,0 +1,19 @@
+/**
+ * @file	  sample_image.hpp
+ * @brief     SampleImage class that contains the sample library to extract features from.
+ * @author    Roxanne van der Pol
+ * @license   MIT
+ */
+
+#ifndef SAMPLE_IMAGE_HPP
+#define SAMPLE_IMAGE_HPP
+
+class SampleImage {
+private:
+	
+public:
+	SampleImage();
+	
+};
+
+#endif // SAMPLE_IMAGE_HPP

--- a/src/sample_image.hpp
+++ b/src/sample_image.hpp
@@ -8,6 +8,9 @@
 #ifndef SAMPLE_IMAGE_HPP
 #define SAMPLE_IMAGE_HPP
 
+#include "open_cv.hpp"
+#include <iostream>
+
 class SampleImage {
   private:
     const char *path; ///< Path of image.
@@ -33,12 +36,6 @@ class SampleImage {
     /**
      * @brief Sets path of image
      *
-     * Sets the path of the SampleImage image by asking the user for input.
-     */
-    void setPath();
-    /**
-     * @brief Sets path of image
-     *
      * Sets the path of the SampleImage image with a new const char * path. If the newPath is invalid, isValid will become false.
      *
      * @param[in]     const char * newPath    The path of the image
@@ -60,7 +57,7 @@ class SampleImage {
      *
      * @return char * path
      */
-    char *getPath();
+    const char *getPath();
     /**
      * @brief Gets image
      *
@@ -76,7 +73,7 @@ class SampleImage {
      *
      * @return bool isValid
      */
-    bool isValid();
+    bool getIsValid();
 };
 
 #endif // SAMPLE_IMAGE_HPP

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,7 +1,10 @@
 #define CATCH_CONFIG_MAIN
-#include "../src/open_cv.hpp"
 #include "catch.hpp"
 
+#include "../src/open_cv.hpp"
+#include "../src/sample_image.hpp"
+
+///< VS7
 TEST_CASE("openCV -- Load image", "[loadImage]") {
     ///< Preconditions:
     cv::Mat image = cv::imread("", -1);
@@ -14,4 +17,20 @@ TEST_CASE("openCV -- Load image", "[loadImage]") {
 
     ///< Compare Postconditions:
     REQUIRE(isFaulty == true);
+}
+
+///< VS8
+TEST_CASE("SampleImage -- empty constructor", "[SampleImage],[imagePaths]") {
+    ///< Preconditions:
+    SampleImage sampleImage_0;
+    SampleImage sampleImage_1;
+
+    ///< Run Test:
+    bool valid_0 = sampleImage_0.getIsValid();
+    sampleImage_1.setPath(sampleImage_0);
+    bool valid_1 = sampleImage_1.getIsValid();
+
+    ///< Compare Postconditions:
+    REQUIRE(valid_0 == false);
+    REQUIRE(valid_1 == false);
 }


### PR DESCRIPTION
- Added SampleImage class in sample_image.cpp / sample_image.hpp
- SampleImage class has an cv::Mat image; const char * path and an isValid bool.
- SampleImage class has setters for path: a const char * approach and by taking the path from an SampleImage & other.
- SampleImage class has getters for path, image and isValid.
- A testcase has been added to test/test_main.cpp to test instantiating and function calls of SampleImage
- Added Doxygen documentation for sample_image.cpp and sample_image.hpp
- SampleImage class has been added to OBJECT_RECOGNITION class diagram on wiki
- Demo code in main.cpp has been updated to use the SampleImage class instead of raw cv::Mat images from openCV.